### PR TITLE
Added a parameter to make chasm histograms optional

### DIFF
--- a/plasm/plasm.py
+++ b/plasm/plasm.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # plasm.py
-# Jim Bagrow
-# Last Modified: 2021-05-19
+# Jim Bagrow and Milo Trujillo
+# Last Modified: 2024-10-23
 
 """PLASM - PLot Analysis Spreads for Meetings
 


### PR DESCRIPTION
For some datasets numpy's `histogram` with auto-binning produces a sub-optimal number of linear bins (tens of thousands, [see here for an extreme example](https://github.com/numpy/numpy/issues/11879)) resulting in extremely slow rendering in chasm and quite large figures when exported to PDF (tens of megabytes).

One solution to this problem is increasing the complexity of `_autobins` to detect this scenario and cap the number of bins, enforce a minimum bin width, or otherwise keep the histograms from getting out of hand. Another solution is to make those changes upstream, and fix the six-year-standing bug in numpy. A third, more trivial solution is to make histograms optional, so in a pinch the user can simply turn them off and still view the CDFs and summary statistics.

This pull request adds a new `show_histograms` boolean parameter to chasm, True by default. When set to False, the bottom row of the figure will be dropped, the figure dimensions are changed appropriately, the second row of plots receives an x-axis label instead of the third, and text related to number of histogram bins is excluded from the right column.